### PR TITLE
DelegateJSONWebToken view permissions

### DIFF
--- a/rest_framework_jwt/refreshtoken/views.py
+++ b/rest_framework_jwt/refreshtoken/views.py
@@ -27,6 +27,10 @@ class DelegateJSONWebToken(generics.CreateAPIView):
     API View that checks the veracity of a refresh token, returning a JWT if it
     is valid.
     """
+    
+    authentication_classes = ()
+    permission_classes = ()
+    
     serializer_class = DelegateJSONWebTokenSerializer
 
     def post(self, request, *args, **kwargs):


### PR DESCRIPTION
DelegateJSONWebToken must explicitly grant access to anyone. If 'IsAuthenticated' is set as a global DRF setting, then it wouldn't be possible to refresh the JWT through the delegate.
